### PR TITLE
Handle deleted user in the assignee list

### DIFF
--- a/src/github_services.py
+++ b/src/github_services.py
@@ -200,6 +200,8 @@ def get_pull_request_dict_with_timestamp(
 
     for assignee in pr_dict['assignees']:
         if event['assignee'] is None or assignee is None:
+            # This situation can arise if a PR was reviewed by a now-deleted
+            # user.
             continue
         if event['assignee']['login'] == assignee['login']:
             assignee['created_at'] = parser.parse(event['created_at'])

--- a/src/github_services.py
+++ b/src/github_services.py
@@ -199,6 +199,8 @@ def get_pull_request_dict_with_timestamp(
     """
 
     for assignee in pr_dict['assignees']:
+        if event['assignee'] is None or assignee is None:
+            continue
         if event['assignee']['login'] == assignee['login']:
             assignee['created_at'] = parser.parse(event['created_at'])
     return pr_dict


### PR DESCRIPTION
This run (https://github.com/oppia/oppia/actions/runs/13056262032) seems to have failed on a PR which had been reviewed by a now deleted user. This PR updates the code to handle this scenario.