### PR TITLE
Fix #22851: Implement pagination and batching for discussion deletion

### DIFF
--- a/src/github_services.py
+++ b/src/github_services.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import builtins
 import collections
 import datetime
 import logging
@@ -47,7 +48,7 @@ def init_service(token: Optional[str]=None) -> None:
         Exception. Given GitHub token is not valid.
     """
     if token is None or token == '':
-        raise Exception(
+        raise builtins.BaseException(
             'Must provide a valid GitHub Personal Access Token.')
 
     global _TOKEN # pylint: disable=global-statement
@@ -66,7 +67,7 @@ def check_token(func: Callable[..., Any]) -> Callable[..., Any]:
     def execute_if_token_initialized(*args: Any, **kwargs: Any) -> Any:
         """Executes the given function if the token is initialized."""
         if _TOKEN is None:
-            raise Exception(
+            raise builtins.BaseException(
                 'Initialize the service with github_services.init_service(TOKEN).')
         return func(*args, **kwargs)
 
@@ -243,7 +244,7 @@ def _get_repository_id(
         data['data']['repository']['id'])
 
     if repository_id is None:
-        raise Exception(
+        raise builtins.BaseException(
             f'{org_name}/{repo_name} doesn\'t exist.')
 
     return repository_id
@@ -298,7 +299,7 @@ def _get_category_id(
             break
 
     if category_id is None:
-        raise Exception(
+        raise builtins.BaseException(
             f'{discussion_category} category is missing in GitHub Discussion.')
 
     assert category_id is not None
@@ -355,7 +356,7 @@ def _get_discussion_ids(
         data = response.json()
 
         if 'errors' in data:
-            raise Exception(
+            raise builtins.BaseException(
                 f'Error fetching discussions: {data["errors"]}')
 
         discussions_data = data['data']['repository']['discussions']
@@ -368,7 +369,7 @@ def _get_discussion_ids(
             break
         cursor = page_info['endCursor']
         if cursor is None:
-            raise Exception(
+            raise builtins.BaseException(
                 'PageInfo says there is a next page, but endCursor is missing.')
 
     if not discussion_ids:
@@ -401,7 +402,7 @@ def _delete_discussion(discussion_id: str) -> None:
     data = response.json()
 
     if 'errors' in data:
-        raise Exception(
+        raise builtins.BaseException(
             f'Error deleting discussion {discussion_id}: {data["errors"]}')
 
     print('--- GraphQL response ---')
@@ -462,7 +463,7 @@ def _delete_discussions_batch(discussion_ids: List[str]) -> None:
     data = response.json()
 
     if 'errors' in data:
-        raise Exception(
+        raise builtins.BaseException(
             f'Error in batch deletion: {data["errors"]}')
 
     print('--- GraphQL response ---')

--- a/src/github_services.py
+++ b/src/github_services.py
@@ -34,6 +34,7 @@ ISSUE_TIMELINE_URL_TEMPLATE = (
     'https://api.github.com/repos/{0}/{1}/issues/{2}/timeline')
 TIMEOUT_SECS = 15
 DELETE_COMMENTS_BEFORE_IN_DAYS = 60
+DISCUSSION_DELETE_BATCH_SIZE = 10
 
 
 def init_service(token: Optional[str]=None) -> None:
@@ -428,9 +429,8 @@ def delete_discussions(
 
     # We batch the deletions to improve performance and avoid flaky timeouts.
     # We use a smaller batch size to avoid hitting the GraphQL complexity limit.
-    batch_size = 10
-    for i in range(0, len(discussion_ids), batch_size):
-        batch = discussion_ids[i:i + batch_size]
+    for i in range(0, len(discussion_ids), DISCUSSION_DELETE_BATCH_SIZE):
+        batch = discussion_ids[i:i + DISCUSSION_DELETE_BATCH_SIZE]
         _delete_discussions_batch(batch)
 
 

--- a/src/github_services.py
+++ b/src/github_services.py
@@ -366,6 +366,9 @@ def _get_discussion_ids(
         if not page_info['hasNextPage']:
             break
         cursor = page_info['endCursor']
+        if cursor is None:
+            raise Exception(
+                'PageInfo says there is a next page, but endCursor is missing.')
 
     if not discussion_ids:
         logging.info('No existing discussions found')

--- a/src/github_services.py
+++ b/src/github_services.py
@@ -16,7 +16,6 @@
 
 from __future__ import annotations
 
-import builtins
 import collections
 import datetime
 import logging
@@ -48,7 +47,7 @@ def init_service(token: Optional[str]=None) -> None:
         Exception. Given GitHub token is not valid.
     """
     if token is None or token == '':
-        raise builtins.BaseException(
+        raise Exception(
             'Must provide a valid GitHub Personal Access Token.')
 
     global _TOKEN # pylint: disable=global-statement
@@ -67,7 +66,7 @@ def check_token(func: Callable[..., Any]) -> Callable[..., Any]:
     def execute_if_token_initialized(*args: Any, **kwargs: Any) -> Any:
         """Executes the given function if the token is initialized."""
         if _TOKEN is None:
-            raise builtins.BaseException(
+            raise Exception(
                 'Initialize the service with github_services.init_service(TOKEN).')
         return func(*args, **kwargs)
 
@@ -244,7 +243,7 @@ def _get_repository_id(
         data['data']['repository']['id'])
 
     if repository_id is None:
-        raise builtins.BaseException(
+        raise Exception(
             f'{org_name}/{repo_name} doesn\'t exist.')
 
     return repository_id
@@ -299,7 +298,7 @@ def _get_category_id(
             break
 
     if category_id is None:
-        raise builtins.BaseException(
+        raise Exception(
             f'{discussion_category} category is missing in GitHub Discussion.')
 
     assert category_id is not None
@@ -356,7 +355,7 @@ def _get_discussion_ids(
         data = response.json()
 
         if 'errors' in data:
-            raise builtins.BaseException(
+            raise Exception(
                 f'Error fetching discussions: {data["errors"]}')
 
         discussions_data = data['data']['repository']['discussions']
@@ -369,7 +368,7 @@ def _get_discussion_ids(
             break
         cursor = page_info['endCursor']
         if cursor is None:
-            raise builtins.BaseException(
+            raise Exception(
                 'PageInfo says there is a next page, but endCursor is missing.')
 
     if not discussion_ids:
@@ -402,7 +401,7 @@ def _delete_discussion(discussion_id: str) -> None:
     data = response.json()
 
     if 'errors' in data:
-        raise builtins.BaseException(
+        raise Exception(
             f'Error deleting discussion {discussion_id}: {data["errors"]}')
 
     print('--- GraphQL response ---')
@@ -447,9 +446,10 @@ def _delete_discussions_batch(discussion_ids: List[str]) -> None:
         )
         variables[f'id{i}'] = discussion_id
 
+    mutations_str = '\n            '.join(mutations)
     query = f"""
         mutation ({', '.join([f'$id{i}: ID!' for i in range(len(discussion_ids))])}) {{
-            {chr(10).join(mutations)}
+            {mutations_str}
         }}
     """
 
@@ -463,7 +463,7 @@ def _delete_discussions_batch(discussion_ids: List[str]) -> None:
     data = response.json()
 
     if 'errors' in data:
-        raise builtins.BaseException(
+        raise Exception(
             f'Error in batch deletion: {data["errors"]}')
 
     print('--- GraphQL response ---')

--- a/src/github_services.py
+++ b/src/github_services.py
@@ -16,7 +16,6 @@
 
 from __future__ import annotations
 
-import builtins
 import collections
 import datetime
 import logging
@@ -47,7 +46,7 @@ def init_service(token: Optional[str]=None) -> None:
         Exception. Given GitHub token is not valid.
     """
     if token is None or token == '':
-        raise builtins.BaseException(
+        raise Exception(
             'Must provide a valid GitHub Personal Access Token.')
 
     global _TOKEN # pylint: disable=global-statement
@@ -66,7 +65,7 @@ def check_token(func: Callable[..., Any]) -> Callable[..., Any]:
     def execute_if_token_initialized(*args: Any, **kwargs: Any) -> Any:
         """Executes the given function if the token is initialized."""
         if _TOKEN is None:
-            raise builtins.BaseException(
+            raise Exception(
                 'Initialize the service with github_services.init_service(TOKEN).')
         return func(*args, **kwargs)
 
@@ -243,7 +242,7 @@ def _get_repository_id(
         data['data']['repository']['id'])
 
     if repository_id is None:
-        raise builtins.BaseException(
+        raise Exception(
             f'{org_name}/{repo_name} doesn\'t exist.')
 
     return repository_id
@@ -298,7 +297,7 @@ def _get_category_id(
             break
 
     if category_id is None:
-        raise builtins.BaseException(
+        raise Exception(
             f'{discussion_category} category is missing in GitHub Discussion.')
 
     assert category_id is not None
@@ -355,7 +354,7 @@ def _get_discussion_ids(
         data = response.json()
 
         if 'errors' in data:
-            raise builtins.BaseException(
+            raise Exception(
                 f'Error fetching discussions: {data["errors"]}')
 
         discussions_data = data['data']['repository']['discussions']
@@ -398,7 +397,7 @@ def _delete_discussion(discussion_id: str) -> None:
     data = response.json()
 
     if 'errors' in data:
-        raise builtins.BaseException(
+        raise Exception(
             f'Error deleting discussion {discussion_id}: {data["errors"]}')
 
     print('--- GraphQL response ---')
@@ -460,7 +459,7 @@ def _delete_discussions_batch(discussion_ids: List[str]) -> None:
     data = response.json()
 
     if 'errors' in data:
-        raise builtins.BaseException(
+        raise Exception(
             f'Error in batch deletion: {data["errors"]}')
 
     print('--- GraphQL response ---')

--- a/src/github_services.py
+++ b/src/github_services.py
@@ -310,9 +310,7 @@ def _get_discussion_ids(
     repo_name: str,
     discussion_category: str,
 ) -> List[str]:
-    """Fetch discussion data from api and return corresponding discussion id and
-    discussion number.
-    """
+    """Fetch all discussion data from api and return corresponding discussion ids."""
 
     category_id = _get_category_id(org_name, repo_name, discussion_category)
 
@@ -322,41 +320,53 @@ def _get_discussion_ids(
     # https://docs.github.com/en/graphql.
 
     query = """
-        query ($org_name: String!, $repository: String!, $category_id: ID!) {
+        query ($org_name: String!, $repository: String!, $category_id: ID!, $cursor: String) {
             repository(owner: $org_name, name: $repository) {
-                discussions(categoryId: $category_id, last:100) {
+                discussions(categoryId: $category_id, first: 100, after: $cursor) {
+                    pageInfo {
+                        hasNextPage
+                        endCursor
+                    }
                     nodes {
                         id
-                        title
-                        number
                     }
                 }
             }
         }
     """
 
-    variables = {
-        'org_name': org_name,
-        'repository': repo_name,
-        'category_id': category_id
-    }
+    discussion_ids: List[str] = []
+    cursor: Optional[str] = None
+    while True:
+        variables = {
+            'org_name': org_name,
+            'repository': repo_name,
+            'category_id': category_id,
+            'cursor': cursor
+        }
 
-    response = requests.post(
-        GITHUB_GRAPHQL_URL,
-        json={'query': query, 'variables': variables},
-        headers=_get_request_headers(),
-        timeout=TIMEOUT_SECS
-    )
-    data = response.json()
-    print('--- GraphQL response ---')
-    print('Discussion ids, titles, numbers')
-    print(data)
+        response = requests.post(
+            GITHUB_GRAPHQL_URL,
+            json={'query': query, 'variables': variables},
+            headers=_get_request_headers(),
+            timeout=TIMEOUT_SECS
+        )
+        response.raise_for_status()
+        data = response.json()
 
-    discussions = data['data']['repository']['discussions']['nodes']
-    discussion_ids = [
-        discussion['id'] for discussion in discussions if discussion['id'] is not None
-    ]
+        if 'errors' in data:
+            raise builtins.BaseException(
+                f'Error fetching discussions: {data["errors"]}')
 
+        discussions_data = data['data']['repository']['discussions']
+        for node in discussions_data['nodes']:
+            if node['id'] is not None:
+                discussion_ids.append(node['id'])
+
+        page_info = discussions_data['pageInfo']
+        if not page_info['hasNextPage']:
+            break
+        cursor = page_info['endCursor']
 
     if not discussion_ids:
         logging.info('No existing discussions found')
@@ -369,10 +379,7 @@ def _delete_discussion(discussion_id: str) -> None:
     query = """
         mutation deleteDiscussion($discussion_id: ID!) {
             deleteDiscussion(input: {id: $discussion_id}) {
-                clientMutationId,
-            		discussion {
-                        title
-                }
+                clientMutationId
             }
         }
     """
@@ -387,10 +394,16 @@ def _delete_discussion(discussion_id: str) -> None:
         headers=_get_request_headers(),
         timeout=TIMEOUT_SECS
     )
+    response.raise_for_status()
+    data = response.json()
+
+    if 'errors' in data:
+        raise builtins.BaseException(
+            f'Error deleting discussion {discussion_id}: {data["errors"]}')
+
     print('--- GraphQL response ---')
     print('Delete discussion')
-    print(response)
-    response.raise_for_status()
+    print(data)
 
 
 @check_token
@@ -410,8 +423,49 @@ def delete_discussions(
     print(discussion_ids)
     print()
     print()
-    for discussion_id in discussion_ids:
-        _delete_discussion(discussion_id)
+
+    # We batch the deletions to improve performance and avoid flaky timeouts.
+    # We use a smaller batch size to avoid hitting the GraphQL complexity limit.
+    batch_size = 10
+    for i in range(0, len(discussion_ids), batch_size):
+        batch = discussion_ids[i:i + batch_size]
+        _delete_discussions_batch(batch)
+
+
+def _delete_discussions_batch(discussion_ids: List[str]) -> None:
+    """Delete multiple GitHub Discussions in a single request."""
+
+    # Using aliases to perform multiple mutations in one request.
+    mutations = []
+    variables = {}
+    for i, discussion_id in enumerate(discussion_ids):
+        mutations.append(
+            f'delete{i}: deleteDiscussion(input: {{id: $id{i}}}) {{ clientMutationId }}'
+        )
+        variables[f'id{i}'] = discussion_id
+
+    query = f"""
+        mutation ({', '.join([f'$id{i}: ID!' for i in range(len(discussion_ids))])}) {{
+            {chr(10).join(mutations)}
+        }}
+    """
+
+    response = requests.post(
+        GITHUB_GRAPHQL_URL,
+        json={'query': query, 'variables': variables},
+        headers=_get_request_headers(),
+        timeout=TIMEOUT_SECS * 2  # Larger timeout for batched requests.
+    )
+    response.raise_for_status()
+    data = response.json()
+
+    if 'errors' in data:
+        raise builtins.BaseException(
+            f'Error in batch deletion: {data["errors"]}')
+
+    print('--- GraphQL response ---')
+    print('Batch delete discussions')
+    print(data)
 
 @check_token
 def create_discussion(

--- a/src/main.py
+++ b/src/main.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import argparse
+import builtins
 import logging
 import os
 import re
@@ -88,7 +89,7 @@ def generate_message(
 
 
     if not os.path.exists(template_path):
-        raise Exception(f'Please add a template file at: {template_path}')
+        raise builtins.BaseException(f'Please add a template file at: {template_path}')
     message = ''
     with open(template_path, 'r', encoding='UTF-8') as file:
         message = file.read()
@@ -117,7 +118,7 @@ def main(args: Optional[List[str]]=None) -> None:
     required_args = ['max_wait_hours', 'discussion_category']
     for arg in required_args:
         if arg is None:
-            raise Exception(f'Please provide {arg} argument.')
+            raise builtins.BaseException(f'Please provide {arg} argument.')
 
     if parsed_args.verbose:
         logging.basicConfig(

--- a/src/main.py
+++ b/src/main.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import argparse
-import builtins
 import logging
 import os
 import re
@@ -89,7 +88,7 @@ def generate_message(
 
 
     if not os.path.exists(template_path):
-        raise builtins.BaseException(f'Please add a template file at: {template_path}')
+        raise Exception(f'Please add a template file at: {template_path}')
     message = ''
     with open(template_path, 'r', encoding='UTF-8') as file:
         message = file.read()
@@ -118,7 +117,7 @@ def main(args: Optional[List[str]]=None) -> None:
     required_args = ['max_wait_hours', 'discussion_category']
     for arg in required_args:
         if arg is None:
-            raise builtins.BaseException(f'Please provide {arg} argument.')
+            raise Exception(f'Please provide {arg} argument.')
 
     if parsed_args.verbose:
         logging.basicConfig(

--- a/tests/github_services_test.py
+++ b/tests/github_services_test.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import builtins
 import datetime
 import json
 import unittest
@@ -39,12 +40,12 @@ class TestInitServices(unittest.TestCase):
 
     def test_init_service_without_token(self) -> None:
 
-        with self.assertRaises(Exception):
+        with self.assertRaises(builtins.BaseException):
             github_services.init_service()
 
     def test_init_service_with_empty_token(self) -> None:
 
-        with self.assertRaises(Exception):
+        with self.assertRaises(builtins.BaseException):
             github_services.init_service('')
 
 

--- a/tests/github_services_test.py
+++ b/tests/github_services_test.py
@@ -379,6 +379,10 @@ class TestGetPrsAssignedToReviewers(unittest.TestCase):
         self.assertEqual(mock_post.call_count, 3)
         self.assertEqual(mocked_response, ['id1', 'id2'])
 
+        # Verify pagination cursor in second page request.
+        _, kwargs2 = mock_post.call_args_list[2]
+        self.assertEqual(kwargs2['json']['variables']['cursor'], 'cursor1')
+
     def test_delete_discussion(self) -> None:
         """Test _delete_discussion."""
 
@@ -419,6 +423,11 @@ class TestGetPrsAssignedToReviewers(unittest.TestCase):
                     self.org_name, self.repo_name, 'test_category_name_1'
                 )
         self.assertEqual(mock_post.call_count, 3)
+
+        # Verify batched deletion payload.
+        _, kwargs2 = mock_post.call_args_list[2]
+        self.assertIn('delete0: deleteDiscussion', kwargs2['json']['query'])
+        self.assertEqual(kwargs2['json']['variables']['id0'], 'test_discussion_id_1')
 
     def test_create_discussion(self) -> None:
         """Test create discussion."""

--- a/tests/github_services_test.py
+++ b/tests/github_services_test.py
@@ -93,6 +93,10 @@ class TestGetPrsAssignedToReviewers(unittest.TestCase):
             'data': {
                 'repository': {
                     'discussions': {
+                        'pageInfo': {
+                            'hasNextPage': False,
+                            'endCursor': None
+                        },
                         'nodes': [
                             {
                                 'id': 'test_discussion_id_1',
@@ -107,10 +111,7 @@ class TestGetPrsAssignedToReviewers(unittest.TestCase):
         self.response_for_delete_discussion = {
             'data': {
                 'deleteDiscussion': {
-                    'clientMutationId': 'null',
-                    'discussion': {
-                        'title': 'Pending Reviews: User-1'
-                    }
+                    'clientMutationId': 'null'
                 }
             }
         }
@@ -334,33 +335,50 @@ class TestGetPrsAssignedToReviewers(unittest.TestCase):
     def test_get_discussion_ids(self) -> None:
         """Test _get_discussion_ids."""
 
-        mock_response_1 = mock.Mock()
-        mock_response_1.json.return_value = self.response_for_get_category_id
-        mock_response_2 = mock.Mock()
-        mock_response_2.json.return_value = self.response_for_get_discussion_ids
-        self.assertTrue(mock_response_1.assert_not_called)
-        self.assertTrue(mock_response_2.assert_not_called)
+        mock_response_cat = mock.Mock()
+        mock_response_cat.json.return_value = self.response_for_get_category_id
+        
+        # Mocking two pages of discussions.
+        mock_response_page1 = mock.Mock()
+        mock_response_page1.json.return_value = {
+            'data': {
+                'repository': {
+                    'discussions': {
+                        'pageInfo': {
+                            'hasNextPage': True,
+                            'endCursor': 'cursor1'
+                        },
+                        'nodes': [{'id': 'id1'}]
+                    }
+                }
+            }
+        }
+        mock_response_page2 = mock.Mock()
+        mock_response_page2.json.return_value = {
+            'data': {
+                'repository': {
+                    'discussions': {
+                        'pageInfo': {
+                            'hasNextPage': False,
+                            'endCursor': None
+                        },
+                        'nodes': [{'id': 'id2'}]
+                    }
+                }
+            }
+        }
 
         with requests_mock.Mocker() as mock_requests:
-
             self.mock_all_get_requests(mock_requests)
-
             with mock.patch('requests.post', side_effect=[
-                mock_response_1, mock_response_2]) as mock_post:
+                mock_response_cat, mock_response_page1, mock_response_page2]) as mock_post:
 
                 mocked_response = github_services._get_discussion_ids(
-                    self.org_name,
-                    self.repo_name,
-                    'test_category_name_1'
+                    self.org_name, self.repo_name, 'test_category_name_1'
                 )
-        self.assertTrue(mock_response_1.assert_called_once)
-        self.assertTrue(mock_response_2.assert_called_once)
-        self.assertEqual(mock_post.call_count, 2)
-        self.assertEqual(
-            mocked_response, [
-                'test_discussion_id_1'
-            ]
-        )
+        
+        self.assertEqual(mock_post.call_count, 3)
+        self.assertEqual(mocked_response, ['id1', 'id2'])
 
     def test_delete_discussion(self) -> None:
         """Test _delete_discussion."""
@@ -380,22 +398,28 @@ class TestGetPrsAssignedToReviewers(unittest.TestCase):
         self.assertEqual(mock_post.call_count, 1)
 
     def test_delete_discussions(self) -> None:
-        """Test _delete_discussions."""
+        """Test delete_discussions."""
 
-        mock_response = mock.Mock()
-        mock_response.json.return_value = self.response_for_delete_discussion
-        self.assertTrue(mock_response.assert_not_called)
-        self.assertTrue(mock_response.assert_not_called)
+        mock_response_cat = mock.Mock()
+        mock_response_cat.json.return_value = self.response_for_get_category_id
+        mock_response_ids = mock.Mock()
+        mock_response_ids.json.return_value = self.response_for_get_discussion_ids
+        mock_response_delete = mock.Mock()
+        mock_response_delete.json.return_value = {
+            'data': {
+                'delete0': {'clientMutationId': 'null'}
+            }
+        }
 
         with requests_mock.Mocker() as mock_requests:
-
             self.mock_all_get_requests(mock_requests)
+            with mock.patch('requests.post', side_effect=[
+                mock_response_cat, mock_response_ids, mock_response_delete]) as mock_post:
 
-            with mock.patch('requests.post', side_effect=[mock_response]) as mock_post:
-
-                github_services._delete_discussion('test_discussion_id_1')
-        self.assertTrue(mock_response.assert_called_once)
-        self.assertEqual(mock_post.call_count, 1)
+                github_services.delete_discussions(
+                    self.org_name, self.repo_name, 'test_category_name_1'
+                )
+        self.assertEqual(mock_post.call_count, 3)
 
     def test_create_discussion(self) -> None:
         """Test create discussion."""

--- a/tests/github_services_test.py
+++ b/tests/github_services_test.py
@@ -16,7 +16,6 @@
 
 from __future__ import annotations
 
-import builtins
 import datetime
 import json
 import unittest
@@ -40,12 +39,12 @@ class TestInitServices(unittest.TestCase):
 
     def test_init_service_without_token(self) -> None:
 
-        with self.assertRaises(builtins.BaseException):
+        with self.assertRaises(Exception):
             github_services.init_service()
 
     def test_init_service_with_empty_token(self) -> None:
 
-        with self.assertRaises(builtins.BaseException):
+        with self.assertRaises(Exception):
             github_services.init_service('')
 
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -16,7 +16,6 @@
 
 from __future__ import annotations
 
-import builtins
 import datetime
 import json
 import unittest
@@ -65,7 +64,7 @@ class GenerateMessageTests(unittest.TestCase):
                 'https://githuburl.pull/123',123, 'user-1', 'test-title', [github_domain.Assignee('user-2', (datetime.datetime.now()))]
             )
             with self.assertRaisesRegex(
-                builtins.BaseException, f'Please add a template file at: {template_path}'):
+                Exception, f'Please add a template file at: {template_path}'):
                 main.generate_message('reviewerName1', [pull_requests], template_path)
 
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import builtins
 import datetime
 import json
 import unittest
@@ -64,7 +65,7 @@ class GenerateMessageTests(unittest.TestCase):
                 'https://githuburl.pull/123',123, 'user-1', 'test-title', [github_domain.Assignee('user-2', (datetime.datetime.now()))]
             )
             with self.assertRaisesRegex(
-                Exception, f'Please add a template file at: {template_path}'):
+                builtins.BaseException, f'Please add a template file at: {template_path}'):
                 main.generate_message('reviewerName1', [pull_requests], template_path)
 
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -127,7 +127,7 @@ class ModuleIntegrationTest(unittest.TestCase):
         }
         self.response_for_delete_discussion = {
             'data': {
-                'delete0': {
+                'deleteDiscussion': {
                     'clientMutationId': 'null'
                 }
             }
@@ -245,10 +245,18 @@ class ModuleIntegrationTest(unittest.TestCase):
 
         # Here we are mocking the POST requests that we will use in the test below.
         # and they are listed in the particular order they will be called.
+        self.response_for_batch_delete_discussion = {
+            'data': {
+                'delete0': {
+                    'clientMutationId': 'null'
+                }
+            }
+        }
+
         post_requests_side_effect_1: List[mock.Mock] = [
             self.mock_post_requests(self.response_for_get_category_ids),
             self.mock_post_requests(self.response_for_get_discussion_ids),
-            self.mock_post_requests(self.response_for_delete_discussion),
+            self.mock_post_requests(self.response_for_batch_delete_discussion),
             self.mock_post_requests(self.response_for_get_category_ids),
             self.mock_post_requests(self.response_for_get_repository_id),
             self.mock_post_requests(self.response_for_create_discussion),
@@ -257,10 +265,10 @@ class ModuleIntegrationTest(unittest.TestCase):
         post_requests_side_effect_2: List[mock.Mock] = [
             self.mock_post_requests(self.response_for_get_category_ids),
             self.mock_post_requests(self.response_for_get_repository_id),
-            self.mock_post_requests(self.response_for_delete_discussion),
+            self.mock_post_requests(self.response_for_batch_delete_discussion),
             self.mock_post_requests(self.response_for_get_category_ids),
             self.mock_post_requests(self.response_for_get_discussion_ids),
-            self.mock_post_requests(self.response_for_delete_discussion),
+            self.mock_post_requests(self.response_for_batch_delete_discussion),
             self.mock_post_requests(self.response_for_get_category_ids),
             self.mock_post_requests(self.response_for_get_repository_id),
             self.mock_post_requests(self.response_for_create_discussion),
@@ -327,7 +335,7 @@ class ModuleIntegrationTest(unittest.TestCase):
         # Mock does not contain return_value attribute, so because of this MyPy throws an
         # error. Thus to avoid the error, we used ignore here.
         self.assertEqual(
-            response_for_delete_discussion.json.return_value, self.response_for_delete_discussion)  # type: ignore[attr-defined]
+            response_for_delete_discussion.json.return_value, self.response_for_batch_delete_discussion)  # type: ignore[attr-defined]
         # Here we use MyPy ignore because the response is of Mock type and
         # Mock does not contain return_value attribute, so because of this MyPy throws an
         # error. Thus to avoid the error, we used ignore here.

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -110,6 +110,10 @@ class ModuleIntegrationTest(unittest.TestCase):
             'data': {
                 'repository': {
                     'discussions': {
+                        'pageInfo': {
+                            'hasNextPage': False,
+                            'endCursor': None
+                        },
                         'nodes': [
                             {
                                 'id': 'test_discussion_id_1',
@@ -123,11 +127,8 @@ class ModuleIntegrationTest(unittest.TestCase):
         }
         self.response_for_delete_discussion = {
             'data': {
-                'deleteDiscussion': {
-                    'clientMutationId': 'null',
-                    'discussion': {
-                        'title': 'Pending Reviews: User-1'
-                    }
+                'delete0': {
+                    'clientMutationId': 'null'
                 }
             }
         }


### PR DESCRIPTION
issue link :
https://github.com/oppia/oppia/issues/22851
https://github.com/oppia/oppia/issues/25784


Description : This PR fixes the issue where old notification discussions were not being deleted in the `Notify Reviewers` category.

changes:
-> Updated `_get_discussion_ids` to use GraphQL pagination (`first: 100`, `after: $cursor`). This ensures that the script identifies all discussions in the category, even if the backlog exceeds 100 items (which was the hard limit previously).
-> Refactored `delete_discussions` to use aliased GraphQL mutations, allowing 10 discussions to be deleted in a single network request. 
-> Added explicit checks for GraphQL `errors` in JSON responses. The script will now correctly identify and report mutation failures instead of silently ignoring them.
-> Updated `github_services_test.py` and `main_test.py` to support the new paginated response structure and batch mutation logic.

proof
<img width="752" height="726" alt="Screenshot 2026-04-26 at 2 06 40 AM" src="https://github.com/user-attachments/assets/821a58d8-3ca5-412f-aa7b-a130f5f821fe" />
